### PR TITLE
Fix faulty pricing for computer-arithmetic book

### DIFF
--- a/data/books/computer-arithmetic.md
+++ b/data/books/computer-arithmetic.md
@@ -1,6 +1,6 @@
 ---
 title: "Computer Arithmetic and Formal Proofs: Verifying Floating-point Algorithms with the Coq System"
-slug: "computer_arithmetics"
+slug: "computer-arithmetic"
 description: >
   This book provides a comprehensive view of how to formally specify and verify tricky floating-point algorithms with the Coq proof assistant.
 recommendation: >
@@ -14,10 +14,10 @@ cover: books/computer_arithmetic.jpg
 language:
   - english
 links:
-  - description: Read Online
-    uri: https://iste.co.uk/book.php?id=1238
+  - description: Publisher's Book Website
+    uri: https://www.sciencedirect.com/book/9781785481123/computer-arithmetic-and-formal-proofs
 difficulty: advanced
-pricing: Paid
+pricing: paid
 ---
 
 Floating-point arithmetic is ubiquitous in modern computing, as it is the tool of choice to approximate real numbers. Due to its limited range and precision, its use can become quite involved and potentially lead to numerous failures. One way to greatly increase confidence in floating-point software is by computer-assisted verification of its correctness proofs.

--- a/src/rocqproverorg_frontend/pages/learn.eml
+++ b/src/rocqproverorg_frontend/pages/learn.eml
@@ -179,7 +179,7 @@ Learn_layout.single_column_layout
         (Data.Book.get_by_slug "mathcomp" |> Option.get)
         ~link:{href = Url.books; title = "See More Books"} %>
       <%s! Learn_components.book_recommendation
-        (Data.Book.get_by_slug "computer_arithmetics" |> Option.get)
+        (Data.Book.get_by_slug "computer-arithmetic" |> Option.get)
         ~link:{href = Url.books; title = "See More Books"} %>
     </div>
 


### PR DESCRIPTION
Also, use ScienceDirect ebook link (online book access for many academics through subscriptions), use consistent name and slug.