### PR TITLE
Fix wrong renaming in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,9 @@ Licenses
 - Content is released under CC BY-SA 4.0.
 - Code that implements the various tools in this repository is released under the ISC license.
 - Code examples within content are released under the UNLICENSE.
-- Design of the site. All rights reserved by the rocq-prover.org project.
+- Design of the site. The website is an overhaul of the OCaml.org design, 
+  whose rights are reserved by the OCaml.org project (http://github.com/ocaml/ocaml.org).
+  For the new design, All rights are reserved by rocq-prover.org project.
 - Rocq logo is released under the UNLICENSE.
 - Abstracts, slides from meetings. Rights retained by contributor.
 
@@ -68,7 +70,7 @@ For more information, please refer to <https://unlicense.org/>
 * ISC
 
 ISC License (ISC)
-Copyright (c) 2021, rocq-prover.org project
+Copyright (c) 2021, OCaml.org project
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
According to this discussion: https://github.com/ocaml/ocaml.org/issues/1917#issuecomment-1887777111 we should at the very least keep the OCaml.org copyright notice. 