### PR TITLE
Redirect refman / to index.html for any version.

### DIFF
--- a/src/rocqproverorg_web/lib/middleware.ml
+++ b/src/rocqproverorg_web/lib/middleware.ml
@@ -41,6 +41,8 @@ let language_manual_version next_handler request =
     | "" :: "stdlib" :: path ->
         let version, path = release_path path in
         "" :: "doc" :: ("V" ^ version) :: "stdlib" :: tweak_base path
+    | [ ""; "doc"; version; "refman" ] ->
+        "" :: "doc" :: version :: "refman" :: [ "index.html" ]
     | "" :: "api" :: path ->
         let version, path = release_path path in
         "" :: "doc" :: ("V" ^ version) :: "api" :: tweak_base path


### PR DESCRIPTION
This should allow using `rocq-prover.org` instead of `coq.inria.fr` in the URLs that we embed in the sources of the refman (cf. https://github.com/coq/coq/pull/20047, cc @ppedrot).