### PR TITLE
Simplify middleware

### DIFF
--- a/src/rocqproverorg_web/lib/middleware.ml
+++ b/src/rocqproverorg_web/lib/middleware.ml
@@ -40,8 +40,8 @@ let language_manual_version next_handler request =
     | "" :: "stdlib" :: path ->
         let version, path = release_path path in
         "" :: "doc" :: ("V" ^ version) :: "stdlib" :: tweak_base path
-    | [ ""; "doc"; version; ("refman" | "stdlib" | "api" | "doc") as path ] ->
-        "" :: "doc" :: version :: path :: [ "index.html" ]
+    | "" :: "doc" :: version :: path ->
+        "" :: "doc" :: version :: tweak_base path
     | "" :: "api" :: path ->
         let version, path = release_path path in
         "" :: "doc" :: ("V" ^ version) :: "api" :: tweak_base path

--- a/src/rocqproverorg_web/lib/middleware.ml
+++ b/src/rocqproverorg_web/lib/middleware.ml
@@ -34,17 +34,15 @@ let language_manual_version next_handler request =
   in
   let path =
     match init_path with
-    | "" :: ("manual" | "refman") :: path ->
-        let version, path = release_path path in
-        "" :: "doc" :: ("V" ^ version) :: "refman" :: tweak_base path
-    | "" :: "stdlib" :: path ->
-        let version, path = release_path path in
-        "" :: "doc" :: ("V" ^ version) :: "stdlib" :: tweak_base path
+    (* When using the /doc/ path, a version is always already provided. *)
     | "" :: "doc" :: version :: path ->
         "" :: "doc" :: version :: tweak_base path
-    | "" :: "api" :: path ->
-        let version, path = release_path path in
-        "" :: "doc" :: ("V" ^ version) :: "api" :: tweak_base path
+    (* We provide shorter paths that always redirect to the latest version. *)
+    | ""
+      :: (("api" | "corelib" | "refman" | "stdlib" | "refman-stdlib") :: _ as
+          path) ->
+        let version = patch Release.latest in
+        "" :: "doc" :: ("V" ^ version) :: tweak_base path
     | [ ""; "releases"; version; "index.html" ] -> [ ""; "releases"; version ]
     | [ ""; "releases"; something ]
       when String.ends_with ~suffix:".html" something ->

--- a/src/rocqproverorg_web/lib/middleware.ml
+++ b/src/rocqproverorg_web/lib/middleware.ml
@@ -29,7 +29,6 @@ let language_manual_version next_handler request =
   in
   let tweak_base u =
     match List.rev u with
-    | _ :: "notes" :: _ -> u
     | base :: _ when String.contains base '.' -> u
     | htap -> List.rev ("index.html" :: htap)
   in


### PR DESCRIPTION
This is a follow-up of my previous changes to redirect `/` to `/index.html` for the documentation. This generalizes to all cases (especially now that we also have `corelib`, `refman-stdlib`, etc.), using existing code for that. In passing, I also remove OCaml.org-specific code and make the overall code simpler. See commit list for details. Tested and ready to merge.