### PR TITLE
Fix various URLs and package names.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Please include images and browser-specific information if the bug is related to 
 We've provided a list of community-driven content below. When adding content to any of these sections, it's best to fork the repo, add your file, and open a pull request (PR).
 
 - [Images](#images)
-- [The OCaml Planet](#ocaml-planet)
+- [The OCaml Planet](#rocq-planet)
 - [Job Board](#content-job)
 - [Success Stories](#content-success-story)
 - [Academic and Industrial Users](#content-user)
@@ -40,9 +40,9 @@ For example, to add a university logo associated with an academic institution, y
 
 Videos or other media should not be added to the OCaml.org GitHub repository.
 
-### <a name="ocaml-planet"></a>Add Your RSS Feed or YouTube Channel to the OCaml Planet
+### <a name="rocq-planet"></a>Add Your RSS Feed or YouTube Channel to the OCaml Planet
 
-Anyone can contribute to the [OCaml Planet](https://ocaml.org/ocaml-planet), which is composed of three types of content:
+Anyone can contribute to the [Rocq Planet](https://rocq-prover.org/rocq-planet), which is composed of three types of content:
 
 - Community blog posts fetched from RSS feeds
 - Videos fetched from YouTube channels

--- a/data/tutorials/guides/1_00_install_Rocq.md
+++ b/data/tutorials/guides/1_00_install_Rocq.md
@@ -122,14 +122,14 @@ Note that installing Rocq using opam will build it from sources,
 which will take several minutes to complete:
  
  ```shell
-$ opam pin add rocq 9.0.0
+$ opam pin add rocq-prover 9.0.0
 ```
 
 Pinning prevents opam from upgrading Rocq automatically, to avoid causing inadvertent breakage in your Rocq projects. 
 You can upgrade Rocq explicitly to `$NEW_VERSION` with essentially the same command:
 
  ```shell
-$ opam pin add rocq $NEW_VERSION
+$ opam pin add rocq-prover $NEW_VERSION
 ```
 
 To ensure that installation was successful, check that `rocq -v` prints the expected version of Rocq.
@@ -172,4 +172,4 @@ Rocq > Eval compute in 2*10.
 
 ## Join the Community
 
-Make sure you [join the Rocq community](/community). You'll find many community members on [Discuss](https://discuss.rocq.org/) or [Discord](https://discord.com/invite/cCYQbqN). These are great places to ask for help if you have any issues.
+Make sure you [join the Rocq community](/community). You'll find many community members on [Discuss](https://discourse.rocq-prover.org/) or [Discord](https://discord.com/invite/cCYQbqN). These are great places to ask for help if you have any issues.

--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,7 @@
 
 (name rocqproverorg)
 
-(documentation "https://rocq-prover.github.io/rocq-prover.org/")
+(documentation "https://rocq-prover.org/")
 
 (source
  (github rocq-prover/rocq-prover.org))

--- a/src/rocqproverorg_data/data_intf.ml
+++ b/src/rocqproverorg_data/data_intf.ml
@@ -518,7 +518,7 @@ module Release = struct
   let github_of_kind = function 
   | `Compiler -> "https://github.com/ocaml/ocaml", id
   | `Coq -> "https://github.com/coq/coq", (fun x -> "V" ^ x)
-  | `Rocq -> "https://github.com/rocq-prover/rocq-prover", id
+  | `Rocq -> "https://github.com/rocq-prover/rocq", id
   | `CoqPlatform -> "https://github.com/coq/platform", id
   | `RocqPlatform -> "https://github.com/rocq-prover/platform", id
 

--- a/src/rocqproverorg_frontend/pages/community.eml
+++ b/src/rocqproverorg_frontend/pages/community.eml
@@ -50,7 +50,7 @@ Community_layout.single_column_layout
       </ul>
       <ul>
         <p class="text-title dark:text-dark-title text-xl font-mono mb-2">Development</p>
-        <%s! social_list_item ~text:("Submit bug reports and feature requests for the Rocq Prover - ") ~href:("https://github.com/rocq") ~left_icon:(Icons.github "w-10 h-10") ~title:("GitHub") "" %>
+        <%s! social_list_item ~text:("Submit bug reports and feature requests for the Rocq Prover - ") ~href:("https://github.com/rocq-prover/rocq/issues") ~left_icon:(Icons.github "w-10 h-10") ~title:("GitHub") "" %>
         <%s! social_list_item ~text:("Ask and help answer Rocq questions - ") ~href:("https://stackoverflow.com/questions/tagged/coq") ~left_icon:(Icons.stackoverflow "w-10 h-10") ~title:("Stack Overflow") "" %>        
       </ul>
       <!-- 

--- a/src/rocqproverorg_frontend/pages/rocq_planet.eml
+++ b/src/rocqproverorg_frontend/pages/rocq_planet.eml
@@ -76,7 +76,7 @@ News_layout.single_column_layout
               To contribute a blog post, or add your RSS feed, check out the Contributing Guide on GitHub.
             </p>
             <div class="flex lg:flex-row mt-8 mr-4">
-              <%s!  Hero_section.hero_button ~left_icon:(Icons.edit "w-6 h-6") ~right_icon:(Icons.link "w-5 h-5") ~text:("Add your RSS feed!") ~href:("https://github.com/rocq-prover/rocq.org/blob/main/CONTRIBUTING.md#rocq-planet") "" %>
+              <%s!  Hero_section.hero_button ~left_icon:(Icons.edit "w-6 h-6") ~right_icon:(Icons.link "w-5 h-5") ~text:("Add your RSS feed!") ~href:("https://github.com/rocq-prover/rocq-prover.org/blob/main/CONTRIBUTING.md#rocq-planet") "" %>
              </div>
           </div>
         </div>


### PR DESCRIPTION
There are still many things to fix in the CONTRIBUTING guide (referencing OCaml.org instead).

From https://coq.zulipchat.com/#narrow/channel/237656-Coq-devs-.26-plugin-devs/topic/How.20will.20the.20coq.2Fcoq.20repo.20be.20renamed.3F, there seems to be a consensus of what the new coq/coq repo name will be.