### PR TITLE
[renaming] coq.zulipchat.com -> rocq-prover.zulipchat.com renaming

### DIFF
--- a/data/news/rocqorg/invitation-to-contribute.md
+++ b/data/news/rocqorg/invitation-to-contribute.md
@@ -13,7 +13,7 @@ Are you passionate about the Rocq Prover and eager to showcase your exciting pro
 
 ![](/media/news/contribute.jpg)
 
-[Zulip](https://coq.zulipchat.com/) serves as a central platform for the Rocq community, where individuals from all backgrounds come together to share knowledge, discuss ideas, and collaborate on Rocq-related endeavors. As an open and inclusive community, we welcome your unique perspectives, experiences, and contributions.
+[Zulip](https://rocq-prover.zulipchat.com/) serves as a central platform for the Rocq community, where individuals from all backgrounds come together to share knowledge, discuss ideas, and collaborate on Rocq-related endeavors. As an open and inclusive community, we welcome your unique perspectives, experiences, and contributions.
 
 
 Join us in shaping the future of Rocq and fostering a vibrant community! Together, we can inspire, educate, and empower developers, enthusiasts, and learners around the world.

--- a/data/pages/privacy_policy.md
+++ b/data/pages/privacy_policy.md
@@ -28,6 +28,6 @@ Data collected includes referral sources, top pages, visit duration, information
 
 We may update this policy as needed to comply with relevant regulations and reflect any new practices. Whenever we make a significant change to our policies, we will also announce them on our company blog or social media profiles.
 
-[Contact us](https://coq.zulipchat.com) if you have any questions, comments, or concerns about this privacy policy, your data, or your rights with respect to your information.
+[Contact us](https://rocq-prover.zulipchat.com) if you have any questions, comments, or concerns about this privacy policy, your data, or your rights with respect to your information.
 
 Last updated: Dec 18, 2024

--- a/data/planet/andrej/the-proposal-for-a-proof-assistants-stackexchange-site.md
+++ b/data/planet/andrej/the-proposal-for-a-proof-assistants-stackexchange-site.md
@@ -9,7 +9,7 @@ authors:
 source:
 ---
 
-<p>Proof assistant communities have grown quite a bit lately. They have active Zulip chats: <a href="https://leanprover.zulipchat.com/">Lean</a>, <a href="https://coq.zulipchat.com/">Coq</a>, <a href="https://agda.zulipchat.com/">Agda</a>, <a href="https://isabelle.zulipchat.com/">Isabelle</a>. These are good for discussions, but less so for knowledge accumulation and organization, and are not indexed by the search engines.</p>
+<p>Proof assistant communities have grown quite a bit lately. They have active Zulip chats: <a href="https://leanprover.zulipchat.com/">Lean</a>, <a href="https://rocq-prover.zulipchat.com/">Coq</a>, <a href="https://agda.zulipchat.com/">Agda</a>, <a href="https://isabelle.zulipchat.com/">Isabelle</a>. These are good for discussions, but less so for knowledge accumulation and organization, and are not indexed by the search engines.</p>
 
 <p>I have therefore created a <a href="https://area51.stackexchange.com/proposals/126242/proof-assistants?referrer=YjczN2ZjMzMyYWRkYjYwOTMzMzJhMjRmZDNiZDJkZGQ1ZGE4MzFiZWQ3YzRlMjYzMzdiMTMxZTBkOTg1ZWNkMdt2-If5yCiayS9kTjQT0iElh8l0mRnZ3CnkNXRmWJGq0">proposal for a new &ldquo;Proof assistants&rdquo;</a> StackExchange site. I believe that such a site would complement very well various Zulips dedicated to specific proof assistants. If you favor the idea, please support it by visiting the proposal and</p>
 

--- a/data/tutorials/platform/1_01_platform_docs.md
+++ b/data/tutorials/platform/1_01_platform_docs.md
@@ -17,7 +17,7 @@ with VsRocq).
 
 Some Ressources:
 
--   The [Zulip channel](https://coq.zulipchat.com/#narrow/stream/437203-Platform-docs)
+-   The [Zulip channel](https://rocq-prover.zulipchat.com/#narrow/stream/437203-Platform-docs)
     we use to discuss and work on the project
 -   The associated [RFC](https://github.com/coq/ceps/pull/91) describing the
     project in details
@@ -29,10 +29,10 @@ We welcome contributions, and there are plenty to do depending on how
 much available time you have:
 
 -   Give feedback on the existing tutorial and how-to guides on
-    [Zulip](https://coq.zulipchat.com/#narrow/stream/437203-Platform-docs)
+    [Zulip](https://rocq-prover.zulipchat.com/#narrow/stream/437203-Platform-docs)
 -   Answer people's questions and share folklore that should be known
     by all on
-    [Zulip](https://coq.zulipchat.com/#narrow/stream/437203-Platform-docs)
+    [Zulip](https://rocq-prover.zulipchat.com/#narrow/stream/437203-Platform-docs)
 -   Help to review tutorials and how-to guides, whether you are an
     expert or not
 -   Help to improve and write tutorial and how-to guides

--- a/src/rocqproverorg_frontend/components/footer.eml
+++ b/src/rocqproverorg_frontend/components/footer.eml
@@ -36,7 +36,7 @@ let policies = [
   ]
 
 let socials = [
-  ("https://coq.zulipchat.com", "Zulip", Icons.zulip);
+  ("https://rocq-prover.zulipchat.com", "Zulip", Icons.zulip);
   ("https://github.com/rocq-prover", "GitHub", Icons.github);
   ("https://discourse.rocq-prover.org", "Discourse", Icons.discourse);
   ("https://mastodon.acm.org/@RocqProver", "Mastodon", Icons.mastodon);

--- a/src/rocqproverorg_frontend/components/header.eml
+++ b/src/rocqproverorg_frontend/components/header.eml
@@ -160,7 +160,7 @@ in
       </li>
       <li>
         <div class="space-x-6 text-2xl flex items-center">
-          <a aria-label="Rocq's Zulip" href="https://coq.zulipchat.com" class="opacity-60 hover:opacity-100 text-content dark:text-dark-title hover:text-primary dark:hover:text-dark-primary">
+          <a aria-label="Rocq's Zulip" href="https://rocq-prover.zulipchat.com" class="opacity-60 hover:opacity-100 text-content dark:text-dark-title hover:text-primary dark:hover:text-dark-primary">
             <%s! Icons.zulip "w-6 h-6" %>
           </a>
           <a aria-label="Rocq's Discourse" href="https://discourse.rocq-prover.org" class="opacity-60 hover:opacity-100 text-content dark:text-dark-title hover:text-primary dark:hover:text-dark-primary">

--- a/src/rocqproverorg_frontend/components/learn_components.eml
+++ b/src/rocqproverorg_frontend/components/learn_components.eml
@@ -201,7 +201,7 @@ let contribute_footer ~href ~description ~recommended_next_tutorials =
       <div class="border-b border-gray-200 px-6 pb-3 md:border-b-0 md:border-r">
         <h2 class="mb-2 text-lg font-bold leading-6">Still need help?</h2>
         <div class="mb-2 text-sm">
-          <a href="https://coq.zulipchat.com/" class="flex items-center gap-2 font-normal sm:text-lg no-underline bg-transparent cursor-pointer hover:underline">
+          <a href="https://rocq-prover.zulipchat.com/" class="flex items-center gap-2 font-normal sm:text-lg no-underline bg-transparent cursor-pointer hover:underline">
             <%s! Icons.user_group "h-5 w-5" %>
             Ask the Rocq Community</a
           >

--- a/src/rocqproverorg_frontend/pages/community.eml
+++ b/src/rocqproverorg_frontend/pages/community.eml
@@ -27,7 +27,7 @@ Community_layout.single_column_layout
               </p>
               <div class="lg:flex-row flex-col flex w-full md:max-w-[70%]">
                <div class="flex lg:flex-row mt-8 mr-4">
-                <%s!  Hero_section.hero_button ~left_icon:(Icons.zulip "w-6 h-6") ~right_icon:(Icons.link "w-5 h-5") ~extra_html:("<strong>Chat</strong> on") ~text:("Zulip") ~href:("https://coq.zulipchat.com/") "" %>
+                <%s!  Hero_section.hero_button ~left_icon:(Icons.zulip "w-6 h-6") ~right_icon:(Icons.link "w-5 h-5") ~extra_html:("<strong>Chat</strong> on") ~text:("Zulip") ~href:("https://rocq-prover.zulipchat.com/") "" %>
                </div>
                <div class="flex lg:flex-row mt-8 mr-4">
                 <%s!  Hero_section.hero_button ~left_icon:(Icons.discourse "w-6 h-6") ~right_icon:(Icons.link "w-5 h-5") ~extra_html:("<strong>Share announcements</strong> on") ~text:("Discourse") ~href:("https://discourse.rocq-prover.org/") "" %>
@@ -50,7 +50,7 @@ Community_layout.single_column_layout
       <p class="text-content dark:text-dark-content mt-4 mb-6">Ask and answer questions, share and discuss Rocq-related articles and posts, let people know about your projects and find collaborators</p>
       <ul>
         <p class="text-title dark:text-dark-title text-xl font-mono mb-2">Discussion</p>
-        <%s! social_list_item ~text:("Casual and high traffic discussions on the Rocq Prover, and ecosystem projects - ") ~href:("https://coq.zulipchat.com") ~left_icon:(Icons.zulip "w-10 h-10") ~title:("Zulip") "" %>
+        <%s! social_list_item ~text:("Casual and high traffic discussions on the Rocq Prover, and ecosystem projects - ") ~href:("https://rocq-prover.zulipchat.com") ~left_icon:(Icons.zulip "w-10 h-10") ~title:("Zulip") "" %>
         <%s! social_list_item ~text:("Announcements and questions in English, Chinese, Spanish, French, German and Russian - ") ~href:("https://discourse.rocq-prover.org/") ~left_icon:(Icons.discourse "w-10 h-10") ~title:("Discourse") "" %>
         <%s! social_list_item ~text:("Ask and help answer Rocq questions - ") ~href:("https://proofassistants.stackexchange.com/questions/tagged/coq") ~left_icon:(Icons.stackoverflow "w-10 h-10") ~title:("Proof Assistants Stack Exchange") "" %>
         <%s! social_list_item ~text:("Follow Rocq questions across all Stack Exchange sites with this RSS feed - ") ~href:("https://stackexchange.com/filters/299857/questions-tagged-coq-on-stackexchange-sites") ~left_icon:(Icons.stackoverflow "w-10 h-10") ~title:("Stack Overflow and other Stack Exchange sites") "" %>


### PR DESCRIPTION
To be merged when the Zulip chat has moved