### PR TITLE
Update Rocq courses Nijmegen.

### DIFF
--- a/data/academic_institutions/radboud.md
+++ b/data/academic_institutions/radboud.md
@@ -9,9 +9,15 @@ location:
     lat: 51.8426
     long: 5.8546
 courses:
-    - name: Type Theory and Coq
+    - name: Type Theory and Rocq
       url: https://cs.ru.nl/~freek/courses/tt-2024/
       teacher: Freek Wiedijk
+      year: 2024
+      lecture_notes: true
+      exercises: true
+    - name: Program Verification with Types and Logic
+      url: https://gitlab.science.ru.nl/program-verification/course-2024-2025
+      teacher: Robbert Krebbers
       year: 2024
       lecture_notes: true
       exercises: true


### PR DESCRIPTION
Adding one more course in Nijmegen that uses Rocq.

(And provide a forward compatible update of the name of the other.)

We have two more courses in the bachelor (by @ehubbers) that use Rocq, but up to my knowledge they do not have a public website. Should we add those?