### PR TITLE
Fix redirects statuses

### DIFF
--- a/src/rocqproverorg_web/lib/redirection.ml
+++ b/src/rocqproverorg_web/lib/redirection.ml
@@ -55,7 +55,7 @@ let documentation req =
   Dream.(redirect ~status:`Moved_Permanently req "/learn")
 
 let opam_packaging req =
-  Dream.(redirect ~status:`Found req ("https://coq.github.io" ^ target req)))
+  Dream.(redirect ~status:`Found req ("https://coq.github.io" ^ target req))
   
 
 let t =
@@ -74,6 +74,6 @@ let t =
        Dream.get "/sites/**" old_sites_modules;
        Dream.get "/modules/**" old_sites_modules;
        Dream.get "/documentation" documentation;
-       Dream.get "/opam-packaging.html" opam_packaging
+       Dream.get "/opam-packaging.html" opam_packaging;
        Dream.get "/opam-packaging" opam_packaging
      ])

--- a/src/rocqproverorg_web/lib/redirection.ml
+++ b/src/rocqproverorg_web/lib/redirection.ml
@@ -20,10 +20,10 @@ let package_docs req =
   Dream.redirect req (Url.Package.documentation package)
 
 let opam_www req =
-  Dream.redirect req "/packages"
+  Dream.(redirect ~status:`Moved_Permanently req "/packages")
 
 let opam req =
-  Dream.redirect req ("https://coq.github.io" ^ Dream.target req)
+  Dream.(redirect ~status:`Found req ("https://coq.github.io" ^ target req))
 
 let http_or_404 ?(not_found = Rocqproverorg_frontend.not_found) opt f =
   Option.fold ~none:(Dream.html ~code:404 (not_found ())) ~some:f opt
@@ -46,10 +46,18 @@ let distrib req =
   | "" :: "library" :: tail -> Some ("/stdlib" ^ String.concat "/" tail)
   | _ -> None
   in
-  http_or_404 newurl (Dream.redirect req)
+  http_or_404 newurl Dream.(redirect ~status:`Found req)
 
 let old_sites_modules req =
-  Dream.redirect req ("https://coq.github.io" ^ Dream.target req)
+  Dream.(redirect ~status:`Found req ("https://coq.github.io" ^ target req))
+
+let documentation req =
+  Dream.(redirect ~status:`Moved_Permanently req "/learn")
+
+let opam_packaging req =
+  Dream.(redirect ~status:`Found req ("https://coq.github.io" ^ target req)))
+  
+
 let t =
   Dream.scope "" []
     ([
@@ -65,4 +73,7 @@ let t =
        Dream.get "/distrib/**" distrib;
        Dream.get "/sites/**" old_sites_modules;
        Dream.get "/modules/**" old_sites_modules;
+       Dream.get "/documentation" documentation;
+       Dream.get "/opam-packaging.html" opam_packaging
+       Dream.get "/opam-packaging" opam_packaging
      ])

--- a/src/rocqproverorg_web/lib/rocqproverorg_web.ml
+++ b/src/rocqproverorg_web/lib/rocqproverorg_web.ml
@@ -9,7 +9,7 @@ let () =
   Logs.set_level ~all:true (Some Debug)
 
 let run () =
-  Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
+  begin[@alert "-deprecated"] Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna) end;
   let state = Rocqproverorg_package.init () in
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port


### PR DESCRIPTION
Also redirect /documentation (permanently to /learn) and /opam-packaging (temporarily to coq.github.io)