### PR TITLE
Fix OCaml links

### DIFF
--- a/data/tutorials/guides/1_00_install_Rocq.md
+++ b/data/tutorials/guides/1_00_install_Rocq.md
@@ -181,4 +181,4 @@ Rocq > Eval compute in 2*10.
 
 ## Join the Community
 
-Make sure you [join the Rocq community](/community). You'll find many community members on [Discuss](https://discourse.rocq-prover.org/) or [Discord](https://discord.com/invite/cCYQbqN). These are great places to ask for help if you have any issues.
+Make sure you [join the Rocq community](/community). You'll find many community members on [Zulip](https://coq.zulipchat.com/), which is a great place to ask for help if you have any issues.


### PR DESCRIPTION
Remove some leftover links to the OCaml world. Also, links on https://rocq-prover.org/community are strange, the one saying "Discourse" at the top of the page redirects to Zulip. (But the one in the list below correctly (?) points to Discourse.) I haven't fixed that as I don't know if it's intentional, but I can easily fix it too.

@mattam82, you'll probably need to update #102 to add this new pointer to the Zulip.