### PR TITLE
Rocq 9.0 releases and changelogs with now working opam instructions

### DIFF
--- a/data/changelog/rocq/2025-03-12-rocq-9.0.md
+++ b/data/changelog/rocq/2025-03-12-rocq-9.0.md
@@ -2,12 +2,20 @@
 title: Release of Rocq 9.0
 description: Release of Rocq 9.0
 tags: [coq]
-changelog: |
-  See the [changelog](https://rocq-prover.org/doc/V9.0.0/refman/changes.html#changes-in-9-0-0) in the reference manual.
-
 ---
 
-We have the pleasure of announcing the first release of Rocq 9.
+We have the pleasure of announcing the first release of Rocq 9. The main changes are:
+
+  - "The Rocq Prover" is the new official name of the project. We leave to users the choice of renaming their projects to reflect this change, see Renaming Advice. The Rocq Prover comes with a new visual identity and website, see The Rocq Prover Website.
+
+  - A single rocq binary dispatches commands for compilation, read-eval-print-loop, documentation building, dependency computation, etc. See The Rocq Prover commands. It corresponds to the rocq-runtime opam package. This is a bare-bones package that does not provide any Gallina code.
+
+  - The Coq standard library has been split into two libraries:
+
+    + A Corelib library (the rocq-core opam package). This is an extended prelude, which is enough to run Rocq tactics and contains the Ltac2 library and bindings for primitive types (integers, floats, arrays and strings).
+
+    + An Stdlib library (the rocq-stdlib opam package). The Stdlib is now maintained out of the main rocq repository. We welcome maintainers and contributors to the new repository. A specific call for contributions will be sent soon.
+
 
 The full list of changes is available [here](/doc/V9.0.0/refman/changes.html) for more details.
 

--- a/data/changelog/rocq/2025-03-12-rocq-9.0.md
+++ b/data/changelog/rocq/2025-03-12-rocq-9.0.md
@@ -1,0 +1,27 @@
+---
+title: Release of Rocq 9.0
+description: Release of Rocq 9.0
+tags: [coq]
+changelog: |
+  See the [changelog](https://rocq-prover.org/doc/V9.0.0/refman/changes.html#changes-in-9-0-0) in the reference manual.
+
+---
+
+We have the pleasure of announcing the first release of Rocq 9.
+
+The full list of changes is available [here](/doc/V9.0.0/refman/changes.html) for more details.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 4.14.1
+opam install rocq-prover.9.0.0
+```
+The source code for the release is also directly available on:
+
+* [GitHub](https://github.com/coq/coq/releases/download/V9.0.0/rocq-9.0.0.tar.gz)

--- a/data/releases/2024.10.1.md
+++ b/data/releases/2024.10.1.md
@@ -2,7 +2,7 @@
 kind: coq-platform
 version: 2024.10.1
 date: 2024-12-02
-is_latest: true
+is_latest: false
 is_lts: false
 intro: |
   This page describes the Coq Platform version **2024.10.1**, released on

--- a/data/releases/2025.01.0.md
+++ b/data/releases/2025.01.0.md
@@ -1,0 +1,87 @@
+---
+kind: coq-platform
+version: 2025.01.0
+date: 2024.02.6
+is_latest: true
+is_lts: false
+intro: |
+  This page describes the Coq Platform version **2025.01.0**, released on
+  Feb 6th, 2025. Go [here](/releases) for a list of all Coq, Rocq and Platform releases.
+  Go [here](https://github.com/coq/platform/releases/) for a list of all Rocq/Coq Platform releases.
+
+  This is the first platform supporting Coq 8.20.
+highlights: |
+  - For Coq 8.20.1
+  - Coq 8.12.2-8.19.0 available
+---
+
+### Recommended binary installers
+
+- [Windows (64 bit) installer for Coq 8.20](https://github.com/coq/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-Windows-x86_64.exe)
+- [MacOS (arm) installer for Coq 8.20](https://github.com/coq/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-MacOS-arm64-UNSIGNED.dmg)
+
+**Note**: the MacOS intel installer is work in progress, and the arm installer is not yet signed.
+  The unsigned Mac installers are hard to use, especially when a signed version has been installed before. 
+  In case you need this urgently (e.g. for a lecture) we can supply a script which signs it locally after installation (such a signature is only valid on the machine it was made on as far as we can tell). 
+
+**Note**: snap is no longer supported (we are working on a replacement)
+
+### General information
+
+See [README](README.md) for general information and installation of Coq Platform.
+
+See [Charter](charter.md) for the concept and goals of Coq Platform.
+
+See [CEP52](https://github.com/coq/ceps/blob/master/text/052-platform-release-cycle.md) for the Coq and Coq Platform release cycle.
+
+See [macOS](doc/README_macOS.md), [Linux](doc/README_Linux.md) and [Windows](doc/README_Windows.md) for detailed installation and usage instructions.
+
+### Major enhancements
+
+- The language server for the VsCoq plugin is now included
+  - VSCoq can be connected directly to the vscoq-language-server supplied by a binary installer
+  - On Windows it is now also possible to connect VSCoq to a language server built from sources. This is achieved by hard linking all cygwin supplied MinGW DLLs into the folders of the executables which use them.
+    This is done via [link_shared_libraries.sh](https://github.com/coq/platform/blob/main/windows/link_shared_libraries.sh) which is called automatically by `coq_platform_make.sh`.
+    In case you install additional binaries which need addtional DLLs are called via VSCoq, e.g. solvers like gappa or z3, you might have to run this script again, but this should be rare since common DLLs are already linked.
+
+Additional packages will be added in an intermediate release.
+
+### Included Versions of Coq
+
+#### Recommended Coq version
+
+- **Coq 8.20.1** with the first [package collection](doc/README~8.20~2025.01.md) from January 2025
+
+#### Compatibility Coq versions
+
+The compatibility versions are intended to help porting packages from an older to the latest release. They can be installed in parallel with other versions of Coq (Coq Platform will create separate opam switches for each Coq version).
+
+- **Coq 8.19.2** with the first [package collection](doc/README~8.19~2024.10.md) from October 2024
+- **Coq 8.18.0** with the first [package collection](doc/README~8.18~2023.11.md) from November 2023
+- **Coq 8.17.1** with the first [package collection](doc/README~8.17~2023.08.md) from August 2023
+- **Coq 8.16.1** with an updated [package collection](doc/README~8.16~2023.08.md) from August 2023 which is as much as possible compatible with the first 8.17.1 package collection
+- **Coq 8.16.1** with the first [package collection](doc/README~8.16~2022.09.md) from September 2022
+- **Coq 8.15.2** with an updated [package collection](doc/README~8.15~2022.09.md) from September 2022 which is as much as possible compatible as possible with the first 8.16.1 package collection
+- **Coq 8.15.2** with the first [package collection](doc/README~8.15~2022.04.md) from April 2022
+- **Coq 8.14.1** with an updated [package collection](https://github.com/coq/platform/blob/main/doc/README~8.14~2022.04.md) from April 2022 which is as much as possible compatible as possible with the first 8.15.2 package collection
+- **Coq 8.14.1** with the first [package collection](https://github.com/coq/platform/blob/main/doc/README~8.14~2022.01.md) from January 2022
+- **Coq 8.13.2** with an updated [package collection](doc/README~8.13~2022.01.md) from January 2022 which is as much as possible compatible as possible with the first 8.14.1 package collection
+- **Coq 8.13.2** with an updated [package collection](doc/README~8.13~2021.09.md) from September 2021
+- **Coq 8.13.2** with the original [package collection](doc/README~8.13~2021.02.md) from February 2021
+- **Coq 8.12.2** with the same [package collection](doc/README~8.12.md) as the 8.12.2 Coq Platform release
+
+### Notes
+
+- __Notes on the macOS Intel installer__: There are some issues with the Intel installer - we recommend to build from sources if you have an Intel Mac.
+
+- __Notes on CoqHammer__: The proof generation component of CoqHammer is available on macOS and Linux only. The CoqHammer tactics, which reconstruct generated proofs, do work on Windows, though. Since the CoqHammer tactic running on macOS and Linux creates simple and fast Coq tactic call snippets which are intended to replace the slow generator tactics, it is possible to use the auto generated tactics on Windows as well. Also you can manually write CoqHammer tactic calls on Windows. 
+
+- __Note on QuickChick__: QuickChick requires an OCaml compiler to run. The binary installers for Coq Platform do not provide OCaml, so QuickChick does not work with the binary installers for macOS and Windows. It is recommended to use the "compile from sources" method if you want to use QuickChick. An alternative method is to install OCaml by other means and have it in the PATH, but this method is not supported by the Coq Platform team. We plan to add an OCaml compiler to the binary installers in a future release.
+
+- __Note on SerAPI__: The SerAPI executables like `sertop` require that either the `COQLIB` environment variable is exported or a `--coqlib=${coqc -where}` or similar option is given. Other Coq tools like `coqc` determine the Coq library path from the binary location, but `sertop` does not (yet).
+
+- __Note on coq_makefile on Windows__: The Windows installers don't supply make because make is quite limited without a posix shell. An addon is supplied which contains a Windows native gnumake and a patched template file for coq_makefile which allows to use coq_makefile and gnumake with CMD as shell.
+
+# Installers
+
+The MacOS Binary installer is still in signing.

--- a/data/releases/2025.01.0.md
+++ b/data/releases/2025.01.0.md
@@ -81,7 +81,3 @@ The compatibility versions are intended to help porting packages from an older t
 - __Note on SerAPI__: The SerAPI executables like `sertop` require that either the `COQLIB` environment variable is exported or a `--coqlib=${coqc -where}` or similar option is given. Other Coq tools like `coqc` determine the Coq library path from the binary location, but `sertop` does not (yet).
 
 - __Note on coq_makefile on Windows__: The Windows installers don't supply make because make is quite limited without a posix shell. An addon is supplied which contains a Windows native gnumake and a patched template file for coq_makefile which allows to use coq_makefile and gnumake with CMD as shell.
-
-# Installers
-
-The MacOS Binary installer is still in signing.

--- a/data/releases/2025.01.0.md
+++ b/data/releases/2025.01.0.md
@@ -23,6 +23,7 @@ highlights: |
 **Note**: the MacOS intel installer is work in progress, and the arm installer is not yet signed.
   The unsigned Mac installers are hard to use, especially when a signed version has been installed before. 
   In case you need this urgently (e.g. for a lecture) we can supply a script which signs it locally after installation (such a signature is only valid on the machine it was made on as far as we can tell). 
+  The previous [MacOS (arm) installer for Coq 8.19.2](https://github.com/coq/platform/releases/download/2024.10.0/Coq-Platform-release-2024.10.0-version.8.19.2024.10-MacOS-arm64.dmg) is signed.
 
 **Note**: snap is no longer supported (we are working on a replacement)
 


### PR DESCRIPTION
Also add the latest platform, 2025.01.0.