### PR TITLE
Update links after restructuring of `src/` in Platform Docs.

### DIFF
--- a/data/tutorials/platform/1_02_rocq_docs.md
+++ b/data/tutorials/platform/1_02_rocq_docs.md
@@ -10,27 +10,27 @@ category: "Documentation"
 ## Writing Proofs
 
 - Introducing Hypothesis with Intro Patterns to Factorize proofs
-  [interactive version](https://rocq-prover.org/platform-docs/Tutorial_intro_patterns.html)
-  and [source code](https://rocq-prover.org/platform-docs/Tutorial_intro_patterns.v)
+  [interactive version](https://rocq-prover.org/platform-docs/writing_proofs/tutorial_intro_patterns.html)
+  and [source code](https://rocq-prover.org/platform-docs/writing_proofs/tutorial_intro_patterns.v)
 - Chaining Tactics to Simplify and Factorize proofs [interactive
-  version](https://rocq-prover.org/platform-docs/Tutorial_Chaining_Tactics.html)
-  and [source code](https://rocq-prover.org/platform-docs/Tutorial_Chaining_Tactics.v)
+  version](https://rocq-prover.org/platform-docs/writing_proofs/tutorial_chaining_tactics.html)
+  and [source code](https://rocq-prover.org/platform-docs/writing_proofs/tutorial_chaining_tactics.v)
 
 ## Ltac2
 
 - <a href="https://github.com/rocq-prover/platform-docs/issues/97" style="color:red">A Brief Introduction to ML like languages</a>
 
 - A brief introduction to manipulating tactics and thunking in Ltac2 [interactive
-  version](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_types_and_thunking.html) and
-  [source code](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_types_and_thunking.v)
+  version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_types_and_thunking.html) and
+  [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_types_and_thunking.v)
 - <a href="https://github.com/rocq-prover/platform-docs/issues/92" style="color:red">Introduction to Ltac2</a>
 - <a href="https://github.com/rocq-prover/platform-docs/issues/93" style="color:red">Quoting in Ltac2</a>
 - Matching Terms and Goals in Ltac2 [interactive
-  version](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_matching_terms_and_goals.html) and
-  [source code](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_matching_terms_and_goals.v)
+  version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_matching_terms_and_goals.html) and
+  [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_matching_terms_and_goals.v)
 - Backtracking in Ltac2 [interactive
-  version](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_backtracking.html) and
-  [source code](https://rocq-prover.org/platform-docs/Tutorial_Ltac2_backtracking.v)
+  version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.html) and
+  [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.v)
 - <a href="https://github.com/rocq-prover/platform-docs/issues/95" style="color:red">Notations in Ltac2</a>
 
 - How to write a contradiction tactic with with Ltac2 [interactive
@@ -40,17 +40,17 @@ category: "Documentation"
 ## Rocq Features
 
 - Searching for Definitions and Lemma [interactive
-  version](https://rocq-prover.org/platform-docs/SearchTutorial.html) and
-  [source code](https://rocq-prover.org/platform-docs/SearchTutorial.v)
+  version](https://rocq-prover.org/platform-docs/features/tutorial_search_for_lemma.html) and
+  [source code](https://rocq-prover.org/platform-docs/features/tutorial_search_for_lemma.v)
 - Basic Library Files and Module Management [interactive
-  version](https://rocq-prover.org/platform-docs/RequireImportTutorial.html)
-  and [source code](https://rocq-prover.org/platform-docs/RequireImportTutorial.v)
+  version](https://rocq-prover.org/platform-docs/features/tutorial_require_import.html)
+  and [source code](https://rocq-prover.org/platform-docs/features/tutorial_require_import.v)
 
 ## Rocq's Theory
 
 - Template Polymorphism vs. Universe Polymorphism: [interactive
-  version](https://rocq-prover.org/platform-docs/Explanation_Template_Polymorphism.html)
-  and [source code](https://rocq-prover.org/platform-docs/Explanation_Template_Polymorphism.v)
-- Explanation of bidirectionality hints: [interactive version](https://rocq-prover.org/platform-docs/Explanation_Bidirectionality_Hints.html)
-  and [source code](https://rocq-prover.org/platform-docs/Explanation_Bidirectionality_Hints.v)
+  version](https://rocq-prover.org/platform-docs/rocq_theory/explanation_template_polymorphism.html)
+  and [source code](https://rocq-prover.org/platform-docs/rocq_theory/explanation_template_polymorphism.v)
+- Explanation of bidirectionality hints: [interactive version](https://rocq-prover.org/platform-docs/rocq_theory/explanation_bidirectionality_hints.html)
+  and [source code](https://rocq-prover.org/platform-docs/rocq_theory/explanation_bidirectionality_hints.v)
 

--- a/data/tutorials/platform/1_03_equations.md
+++ b/data/tutorials/platform/1_03_equations.md
@@ -17,18 +17,18 @@ function and its associated elimination principle.
 ## Documentation of Equations
 
 -   The Basics of Equations [interactive
-    version](https://rocq-prover.org/platform-docs/Tutorial_Equations_basics.html)
+    version](https://rocq-prover.org/platform-docs/equations/tutorial_basics.html)
     and [source
-    code](https://rocq-prover.org/platform-docs/Tutorial_Equations_basics.v)
+    code](https://rocq-prover.org/platform-docs/equations/tutorial_basics.v)
 -   Equations and Obligations [interactive
-    version](https://rocq-prover.org/platform-docs/Tutorial_Equations_Obligations.html)
+    version](https://rocq-prover.org/platform-docs/equations/tutorial_obligations.html)
     and [source
-    code](https://rocq-prover.org/platform-docs/Tutorial_Equations_Obligations.v)
+    code](https://rocq-prover.org/platform-docs/equations/tutorial_obligations.v)
 -   Equations and Well-founded Recursion [interactive
-    version](https://rocq-prover.org/platform-docs/Tutorial_Equations_wf.html)
+    version](https://rocq-prover.org/platform-docs/equations/tutorial_wf_recursion.html)
     and [source
-    code](https://rocq-prover.org/platform-docs/Tutorial_Equations_wf.v)
+    code](https://rocq-prover.org/platform-docs/equations/tutorial_wf_recursion.v)
 -   Equations and Indexed inductive types, and tactics [interactive
-    version](https://rocq-prover.org/platform-docs/Tutorial_Equations_indexed.html)
+    version](https://rocq-prover.org/platform-docs/equations/tutorial_indexed.html)
     and [source
-    code](https://rocq-prover.org/platform-docs/Tutorial_Equations_indexed.v)
+    code](https://rocq-prover.org/platform-docs/equations/tutorial_indexed.v)

--- a/data/tutorials/platform/1_04_hierarchy_builder_docs.md
+++ b/data/tutorials/platform/1_04_hierarchy_builder_docs.md
@@ -15,4 +15,4 @@ while ensuring that a few good properties hold.
 
 ## Documentation of Hierarchy Builder
 
--   Hierarchy Builder [source code](https://rocq-prover.org/platform-docs/Tutorial_hierarchy_builder.v) (no functional interactive version yet).
+-   Hierarchy Builder [source code](https://rocq-prover.org/platform-docs/hierarchy_builder/tutorial_basics.v) (no functional interactive version yet).


### PR DESCRIPTION
To be merged after https://github.com/rocq-prover/platform-docs/pull/114 is merged and deployed.